### PR TITLE
Use an enum for passing around the detected note name

### DIFF
--- a/main/globals.h
+++ b/main/globals.h
@@ -12,7 +12,23 @@
 #if !defined(TUNER_GLOBALS)
 #define TUNER_GLOBALS
 
-static const char *note_names[] = {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"};
+typedef enum {
+    NOTE_C = 0,
+    NOTE_C_SHARP,
+    NOTE_D,
+    NOTE_D_SHARP,
+    NOTE_E,
+    NOTE_F,
+    NOTE_F_SHARP,
+    NOTE_G,
+    NOTE_G_SHARP,
+    NOTE_A,
+    NOTE_A_SHARP,
+    NOTE_B,
+    NOTE_NONE
+} TunerNoteName;
+
+static const char *note_names[] = {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B", "-"};
 static const char *no_freq_name = "-";
 
 /// @brief Gets the currently-detected frequency (thread safe).

--- a/main/tuner_ui_interface.h
+++ b/main/tuner_ui_interface.h
@@ -8,6 +8,7 @@
 
 #include <stdlib.h>
 
+#include "globals.h"
 #include "lvgl.h"
 
 /// @brief Implement a tuner UI by implementing this interface.
@@ -31,7 +32,7 @@ typedef struct {
     void (*init)(lv_obj_t *screen);
     
     /// @brief Display the frequency/note/cents/etc.
-    void (*display_frequency)(float frequency, const char *note_name, float cents);
+    void (*display_frequency)(float frequency, TunerNoteName note_name, float cents);
 
     /// @brief Perform any cleanup needed (this UI is being deactivated).
     ///

--- a/main/tuner_ui_needle.h
+++ b/main/tuner_ui_needle.h
@@ -6,12 +6,13 @@
 #if !defined(TUNER_NEEDLE_GUI)
 #define TUNER_NEEDLE_GUI
 
+#include "globals.h"
 #include "lvgl.h"
 
 uint8_t needle_gui_get_id();
 const char * needle_gui_get_name();
 void needle_gui_init(lv_obj_t *screen);
-void needle_gui_display_frequency(float frequency, const char *note_name, float cents);
+void needle_gui_display_frequency(float frequency, TunerNoteName note_name, float cents);
 void needle_gui_cleanup();
 
 #endif

--- a/main/tuner_ui_strobe.cpp
+++ b/main/tuner_ui_strobe.cpp
@@ -30,7 +30,7 @@ extern "C" const lv_font_t raleway_128;
 void strobe_create_arcs(lv_obj_t * parent);
 void strobe_create_labels(lv_obj_t * parent);
 void strobe_set_note_name_cb(lv_timer_t * timer);
-void strobe_update_note_name(const char *new_value);
+void strobe_update_note_name(TunerNoteName new_value);
 
 //
 // Local Variables
@@ -39,7 +39,7 @@ lv_obj_t *strobe_parent_screen = NULL;
 
 // Keep track of the last note that was displayed so telling the UI to update
 // can be avoided if it is the same.
-const char *strobeLastDisplayedNote = no_freq_name;
+TunerNoteName strobe_last_displayed_note = NOTE_NONE;
 
 lv_timer_t *strobe_note_name_update_timer = NULL;
 
@@ -78,14 +78,14 @@ void strobe_gui_init(lv_obj_t *screen) {
     lv_timer_reset(strobe_note_name_update_timer);
 }
 
-void strobe_gui_display_frequency(float frequency, const char *note_name, float cents) {
-    if (note_name != NULL) {
+void strobe_gui_display_frequency(float frequency, TunerNoteName note_name, float cents) {
+    if (note_name != NOTE_NONE) {
         lv_label_set_text_fmt(strobe_frequency_label, "%.2f", frequency);
         lv_obj_clear_flag(strobe_frequency_label, LV_OBJ_FLAG_HIDDEN);
 
-        if (strobeLastDisplayedNote != note_name) {
+        if (strobe_last_displayed_note != note_name) {
             strobe_update_note_name(note_name);
-            strobeLastDisplayedNote = note_name; // prevent setting this so often to help prevent an LVGL crash
+            strobe_last_displayed_note = note_name; // prevent setting this so often to help prevent an LVGL crash
         }
 
         // Calculate where the indicator bar should be left-to right based on the cents
@@ -109,9 +109,9 @@ void strobe_gui_display_frequency(float frequency, const char *note_name, float 
         lv_obj_clear_flag(strobe_cents_label, LV_OBJ_FLAG_HIDDEN);
     } else {
         // Hide the pitch and indicators since it's not detected
-        if (strobeLastDisplayedNote != no_freq_name) {
-            strobe_update_note_name(no_freq_name);
-            strobeLastDisplayedNote = no_freq_name;
+        if (strobe_last_displayed_note != NOTE_NONE) {
+            strobe_update_note_name(NOTE_NONE);
+            strobe_last_displayed_note = NOTE_NONE;
         }
 
         // Hide the strobe arcs, frequency, and cents labels
@@ -242,19 +242,19 @@ void strobe_set_note_name_cb(lv_timer_t * timer) {
 
     // TODO: Maybe change this to use images instead of const char*
     // because the app is crashing too often with this mechanism.
-    const char *note_string = (const char *)lv_timer_get_user_data(timer);
-    lv_label_set_text_static(strobe_note_name_label, note_string);
+    const char *note_name = (const char *)lv_timer_get_user_data(timer);
+    lv_label_set_text_static(strobe_note_name_label, note_name);
 
     lv_timer_pause(timer);
 
     lvgl_port_unlock();
 }
 
-void strobe_update_note_name(const char *new_value) {
+void strobe_update_note_name(TunerNoteName new_value) {
     // Set the note name with a timer so it doesn't get
     // set too often for LVGL. ADC makes it run SUPER
     // fast and can crash the software.
-    lv_timer_set_user_data(strobe_note_name_update_timer, (void *)new_value);
+    lv_timer_set_user_data(strobe_note_name_update_timer, (void *)note_names[(int)new_value]);
     lv_timer_set_period(strobe_note_name_update_timer, (uint32_t)userSettings->noteDebounceInterval);
     lv_timer_reset(strobe_note_name_update_timer);
     lv_timer_resume(strobe_note_name_update_timer);

--- a/main/tuner_ui_strobe.h
+++ b/main/tuner_ui_strobe.h
@@ -6,12 +6,13 @@
 #if !defined(TUNER_STROBE_GUI)
 #define TUNER_STROBE_GUI
 
+#include "globals.h"
 #include "lvgl.h"
 
 uint8_t strobe_gui_get_id();
 const char * strobe_gui_get_name();
 void strobe_gui_init(lv_obj_t *screen);
-void strobe_gui_display_frequency(float frequency, const char *note_name, float cents);
+void strobe_gui_display_frequency(float frequency, TunerNoteName note_name, float cents);
 void strobe_gui_cleanup();
 
 #endif


### PR DESCRIPTION
This gets rid of most of the weird glitches with the note name but not all.