### PR TITLE
Add a fade animation that keeps the last note around for 2 seconds

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
         "interface/ftdi/esp32_devkitj_v1.cfg",
         "target/esp32.cfg"
     ],
-    "idf.port": "/dev/tty.usbserial-10",
+    "idf.port": "/dev/tty.usbserial-210",
     "idf.flashType": "UART",
     "files.associations": {
         "bitset": "cpp",

--- a/main/defines.h
+++ b/main/defines.h
@@ -86,4 +86,9 @@
 
 #define GEAR_SYMBOL "\xEF\x80\x93"
 
+//
+// When the pitch stops being detected, the note can fade out. This is how long
+// that animation is set to run for.
+#define LAST_NOTE_FADE_INTERVAL_MS  2000
+
 #endif

--- a/main/tuner_ui_strobe.cpp
+++ b/main/tuner_ui_strobe.cpp
@@ -15,12 +15,6 @@
 
 static const char *STROBE = "STROBE";
 
-/// The strobe works by changing the rotation of the lv_arc widgets by a certain
-/// amount each time it receives a frequency. Changing the rotation too much
-/// makes the rotation direction nearly impossible to determine and this keeps
-/// that under control.
-#define MAX_CENTS_ROTATION 30
-
 extern UserSettings *userSettings;
 extern lv_coord_t screen_width;
 extern lv_coord_t screen_height;
@@ -41,6 +35,10 @@ LV_IMG_DECLARE(tuner_font_image_sharp)
 void strobe_create_labels(lv_obj_t * parent);
 void strobe_create_arcs(lv_obj_t * parent);
 void strobe_update_note_name(TunerNoteName new_value);
+void strobe_start_note_fade_animation();
+void strobe_stop_note_fade_animation();
+void strobe_last_note_anim_cb(lv_obj_t *obj, int32_t value);
+void strobe_last_note_anim_completed_cb(lv_anim_t *);
 
 //
 // Local Variables
@@ -51,7 +49,8 @@ lv_obj_t *strobe_parent_screen = NULL;
 // can be avoided if it is the same.
 TunerNoteName strobe_last_displayed_note = NOTE_NONE;
 
-lv_obj_t *strobe_note_name_img;
+lv_obj_t *strobe_note_img_container;
+lv_obj_t *strobe_note_img;
 lv_obj_t *strobe_sharp_img;
 
 lv_obj_t *strobe_frequency_label;
@@ -65,6 +64,8 @@ lv_obj_t *strobe_arc2;
 lv_obj_t *strobe_arc3;
 
 float strobe_rotation_current_pos = 0;
+
+lv_anim_t *strobe_last_note_anim = NULL;
 
 uint8_t strobe_gui_get_id() {
     return 1;
@@ -81,6 +82,7 @@ void strobe_gui_init(lv_obj_t *screen) {
 }
 
 void strobe_gui_display_frequency(float frequency, TunerNoteName note_name, float cents) {
+    if (note_name < 0) { return; } // Strangely I'm sometimes seeing negative values. No idea how.
     if (note_name != NOTE_NONE) {
         lv_label_set_text_fmt(strobe_frequency_label, "%.2f", frequency);
         lv_obj_clear_flag(strobe_frequency_label, LV_OBJ_FLAG_HIDDEN);
@@ -122,18 +124,16 @@ void strobe_gui_display_frequency(float frequency, TunerNoteName note_name, floa
         lv_obj_add_flag(strobe_frequency_label, LV_OBJ_FLAG_HIDDEN);
     }
 
-    float amount_to_rotate = cents;
-    if (amount_to_rotate > MAX_CENTS_ROTATION) {
-        amount_to_rotate = MAX_CENTS_ROTATION;
-    } else if (amount_to_rotate < MAX_CENTS_ROTATION) {
-        amount_to_rotate = -MAX_CENTS_ROTATION;
-    }
-
+    float amount_to_rotate = cents / 2; // Dividing the cents in half for the amount of rotation seems to feel about right
     if (amount_to_rotate != 0) {
         strobe_rotation_current_pos += cents; // This will make the strobe rotate left or right depending on how off the tuning is
         lv_arc_set_rotation(strobe_arc1, strobe_rotation_current_pos);
         lv_arc_set_rotation(strobe_arc2, strobe_rotation_current_pos + 120); // 1/3 of a circle ahead
         lv_arc_set_rotation(strobe_arc3, strobe_rotation_current_pos + 240); // 2/3 of a circle ahead
+
+        // With the UI updating as much as possible, this keeps the tuning
+        // stable by yielding for just a teeny amount.
+        vTaskDelay(1);
     }
 }
 
@@ -142,26 +142,34 @@ void strobe_gui_cleanup() {
 }
 
 void strobe_create_labels(lv_obj_t * parent) {
+    // Place the note name and # symbole in the same container so the opacity
+    // can be animated.
+    strobe_note_img_container = lv_obj_create(parent);
+    lv_obj_set_size(strobe_note_img_container, lv_pct(100), lv_pct(100));
+    lv_obj_set_style_bg_opa(strobe_note_img_container, LV_OPA_0, 0);
+    lv_obj_set_style_border_width(strobe_note_img_container, 0, 0);
+    lv_obj_set_scrollbar_mode(strobe_note_img_container, LV_SCROLLBAR_MODE_OFF);
+    lv_obj_center(strobe_note_img_container);
+
     // Note Name Image (the big name in the middle of the screen)
-    strobe_note_name_img = lv_image_create(parent);
-    lv_image_set_src(strobe_note_name_img, &tuner_font_image_none);
-    lv_obj_center(strobe_note_name_img);
+    strobe_note_img = lv_image_create(strobe_note_img_container);
+    lv_image_set_src(strobe_note_img, &tuner_font_image_none);
+    lv_obj_center(strobe_note_img);
 
-    strobe_sharp_img = lv_image_create(parent);
+    strobe_sharp_img = lv_image_create(strobe_note_img_container);
     lv_image_set_src(strobe_sharp_img, &tuner_font_image_sharp);
-
-    lv_obj_align_to(strobe_sharp_img, strobe_note_name_img, LV_ALIGN_TOP_RIGHT, 70, -45);
+    lv_obj_align_to(strobe_sharp_img, strobe_note_img, LV_ALIGN_TOP_RIGHT, 70, -45);
     lv_obj_add_flag(strobe_sharp_img, LV_OBJ_FLAG_HIDDEN);
     
     // Enable recoloring on the images
-    lv_obj_set_style_img_recolor_opa(strobe_note_name_img, LV_OPA_COVER, LV_PART_MAIN);
+    lv_obj_set_style_img_recolor_opa(strobe_note_img, LV_OPA_COVER, LV_PART_MAIN);
     lv_obj_set_style_img_recolor_opa(strobe_sharp_img, LV_OPA_COVER, LV_PART_MAIN);
     lv_palette_t palette = userSettings->noteNamePalette;
     if (palette == LV_PALETTE_NONE) {
-        lv_obj_set_style_img_recolor(strobe_note_name_img, lv_color_white(), 0);
+        lv_obj_set_style_img_recolor(strobe_note_img, lv_color_white(), 0);
         lv_obj_set_style_img_recolor(strobe_sharp_img, lv_color_white(), 0);
     } else {
-        lv_obj_set_style_img_recolor(strobe_note_name_img, lv_palette_main(palette), 0);
+        lv_obj_set_style_img_recolor(strobe_note_img, lv_palette_main(palette), 0);
         lv_obj_set_style_img_recolor(strobe_sharp_img, lv_palette_main(palette), 0);
     }
 
@@ -197,6 +205,7 @@ void strobe_create_arcs(lv_obj_t * parent) {
     lv_obj_set_size(strobe_arc_container, lv_pct(100), lv_pct(100));
     lv_obj_set_style_bg_opa(strobe_arc_container, LV_OPA_0, 0);
     lv_obj_set_style_border_width(strobe_arc_container, 0, 0);
+    lv_obj_set_scrollbar_mode(strobe_arc_container, LV_SCROLLBAR_MODE_OFF);
     lv_obj_center(strobe_arc_container);
 
     strobe_arc1 = lv_arc_create(strobe_arc_container);
@@ -243,6 +252,7 @@ void strobe_update_note_name(TunerNoteName new_value) {
     // fast and can crash the software.
     const lv_image_dsc_t *img_desc;
     bool show_sharp_symbol = false;
+    bool show_note_fade_anim = false;
     switch (new_value) {
     case NOTE_A_SHARP:
         show_sharp_symbol = true;
@@ -275,16 +285,70 @@ void strobe_update_note_name(TunerNoteName new_value) {
     case NOTE_G:
         img_desc = &tuner_font_image_g;
         break;
-    default:
-        img_desc = &tuner_font_image_none;
+    case NOTE_NONE:
+        show_note_fade_anim = true;
         break;
+    default:
+        return;
     }
 
-    if (show_sharp_symbol) {
-        lv_obj_remove_flag(strobe_sharp_img, LV_OBJ_FLAG_HIDDEN);
+    if (show_note_fade_anim) {
+        strobe_start_note_fade_animation();
     } else {
-        lv_obj_add_flag(strobe_sharp_img, LV_OBJ_FLAG_HIDDEN);
+        strobe_stop_note_fade_animation();
+
+        if (show_sharp_symbol) {
+            lv_obj_clear_flag(strobe_sharp_img, LV_OBJ_FLAG_HIDDEN);
+        } else {
+            lv_obj_add_flag(strobe_sharp_img, LV_OBJ_FLAG_HIDDEN);
+        }
+
+        lv_image_set_src(strobe_note_img, img_desc);
+    }
+}
+
+void strobe_start_note_fade_animation() {
+    strobe_last_note_anim = (lv_anim_t *)malloc(sizeof(lv_anim_t));
+    lv_anim_init(strobe_last_note_anim);
+    lv_anim_set_exec_cb(strobe_last_note_anim, (lv_anim_exec_xcb_t)strobe_last_note_anim_cb);
+    lv_anim_set_completed_cb(strobe_last_note_anim, strobe_last_note_anim_completed_cb);
+    lv_anim_set_var(strobe_last_note_anim, strobe_note_img_container);
+    lv_anim_set_duration(strobe_last_note_anim, LAST_NOTE_FADE_INTERVAL_MS);
+    lv_anim_set_values(strobe_last_note_anim, 100, 0); // Fade from 100% to 0% opacity
+    lv_anim_start(strobe_last_note_anim);
+}
+
+void strobe_stop_note_fade_animation() {
+    lv_obj_set_style_opa(strobe_note_img_container, LV_OPA_100, 0);
+    if (strobe_last_note_anim == NULL) {
+        return;
+    }
+    lv_anim_del_all();
+    delete(strobe_last_note_anim);
+    strobe_last_note_anim = NULL;
+}
+
+void strobe_last_note_anim_cb(lv_obj_t *obj, int32_t value) {
+    if (!lvgl_port_lock(0)) {
+        return;
     }
 
-    lv_image_set_src(strobe_note_name_img, img_desc);
+    lv_obj_set_style_opa(obj, value, LV_PART_MAIN);
+
+    lvgl_port_unlock();
+}
+
+void strobe_last_note_anim_completed_cb(lv_anim_t *) {
+    if (!lvgl_port_lock(0)) {
+        return;
+    }
+    // The animation has completed so hide the note name and set
+    // the opacity back to 100%.
+    lv_obj_add_flag(strobe_sharp_img, LV_OBJ_FLAG_HIDDEN);
+    lv_image_set_src(strobe_note_img, &tuner_font_image_none);
+    strobe_last_displayed_note = NOTE_NONE;
+
+    strobe_stop_note_fade_animation();
+
+    lvgl_port_unlock();
 }


### PR DESCRIPTION
This change is on the strobe and the needle tuner.

Also changes the strobe amount of movement by removing the max rotation in favor of just dividing the # of cents in half before passing it along to rotate the arcs. This makes them feel a bit more precise and half of 50 is 25 which is now the max amount of rotation at once instead of 30. Seems to feel about right.